### PR TITLE
Adiciona link para edição no rodapé (link para o md no repo) e atualiza .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _site/
 .sass-cache/
 .jekyll-metadata
+public/

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -1,0 +1,41 @@
+{{ partial "head.html" . }}
+<div class="content container">
+  <div class="post">
+    <h1 class="post-title">{{ .Title }}</h1>
+    <span class="post-date">{{ .Date.Format "Jan 2, 2006" }}{{ if not .Site.Params.hideReadingTime }} &middot; {{ .ReadingTime }} minute read{{ end }}{{ if .Site.DisqusShortname }} &middot; <a href="{{ .Permalink }}#disqus_thread">Comments</a>{{ end }}
+    {{ if isset .Params "categories" }}
+    <br/>
+    {{ range .Params.categories }}<a class="label" href="{{ "/categories/" | absURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}
+    {{ end }}</span>
+    {{ .Content }}
+    <hr />
+    Para editar este post basta clicar <a href="https://github.com/gomex/gomex.me/tree/master/content/{{ .File.Path }}">aqui</a>.
+  </div>
+  {{ if .Site.DisqusShortname }}<div id="disqus_thread"></div>{{ end }}
+</div>
+
+{{ with .Site.DisqusShortname }}
+<script type="text/javascript">
+var disqus_shortname = {{ . }};
+(function () {
+    var s = document.createElement('script'); s.async = true;
+    s.type = 'text/javascript';
+    s.src = '//' + disqus_shortname + '.disqus.com/count.js';
+    (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
+}());
+</script>
+{{ end }}
+
+{{ with .Site.DisqusShortname }}
+<script type="text/javascript">
+    var disqus_shortname = {{ . }};
+    (function() {
+        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+    })();
+</script>
+<noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+<a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
+{{ end }}
+{{ partial "foot.html" . }}


### PR DESCRIPTION
Adiciona um link no rodapé de todos os posts (automático) contendo o caminho para o arquivo markdown que o gera

Também adiciona o diretório "public/" no .gitignore